### PR TITLE
Changed the VME interrupt release method from the default RORA to ROA…

### DIFF
--- a/mcaApp/SISSrc/drvSIS3820.cpp
+++ b/mcaApp/SISSrc/drvSIS3820.cpp
@@ -244,6 +244,12 @@ drvSIS3820::drvSIS3820(const char *portName, int baseAddress, int interruptVecto
 
   erase();
 
+  /* Set IRQ method to Release on Acknowledge (ROAK)*/  
+  asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, "%s:%s: irq ROAK = 0x%08x\n", 
+            driverName, functionName, registers_->irq_config_reg);
+
+  registers_->irq_config_reg |= SIS3820_IRQ_ROAK;
+
   /* Enable interrupts in hardware */  
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW, 
             "%s:%s: irq before enabling interrupts= 0x%08x\n", 


### PR DESCRIPTION
…K for CPU boards that use the Tsi148 and rely on software initiated IACK cycles.

This change prevents BERR due to out-of-order VMEbus transactions. The attached screenshot shows an interrupt acknowledge cycle on the left and the resulting BERR on the right (ignore the 2ms delay between, that has been changed in the BSP to 150us).
![Uploading BERRStruckRORA.png…]()
