### PR TITLE
TECS is not supported on DP5G (ie. GammaRad) devices

### DIFF
--- a/mcaApp/AmptekSrc/drvAmptek.cpp
+++ b/mcaApp/AmptekSrc/drvAmptek.cpp
@@ -638,7 +638,9 @@ asynStatus drvAmptek::parseConfiguration()
     parseConfigInt("HVSE=", amptekSetHighVoltage_);
     
     // Detector temperature
-    parseConfigDouble("TECS=", amptekSetDetTemp_);
+    if ((dppType_ == dppDP5) || (dppType_ == dppPX5)) {
+        parseConfigDouble("TECS=", amptekSetDetTemp_);
+    }
 
     // MCS low channel
     parseConfigInt("MCSL=", amptekMCSLowChannel_);


### PR DESCRIPTION
I'm getting these messages at IOC startup when talking to GammaRad5 devices, based on DP5G controller:

```parseConfigDouble string TECS= not found in configuration```

According to https://cars.uchicago.edu/software/epics/DP5%20Programmer's%20Guide%20B1.pdf, page 172, TECS is not supported on DP5G.