### PR TITLE
Set dppType_ before its use

### DIFF
--- a/mcaApp/AmptekSrc/drvAmptek.cpp
+++ b/mcaApp/AmptekSrc/drvAmptek.cpp
@@ -195,7 +195,6 @@ asynStatus drvAmptek::connectDevice()
         return asynError;
     }
     readConfigurationFromHardware();
-    dppType_ = (dp5DppTypes)CH_.DP5Stat.m_DP5_Status.DEVICE_ID;
     strTemp = CH_.DP5Stat.GetDeviceNameFromVal(CH_.DP5Stat.m_DP5_Status.DEVICE_ID);
     setStringParam(amptekModel_, strTemp.c_str());
     setIntegerParam(amptekSerialNumber_, CH_.DP5Stat.m_DP5_Status.SerialNumber);
@@ -859,9 +858,11 @@ asynStatus drvAmptek::readConfigurationFromHardware()
     }
     if (CH_.HwCfgReady) {        // config is ready
       haveConfigFromHW_ = true;
+      dppType_ = (dp5DppTypes)CH_.DP5Stat.m_DP5_Status.DEVICE_ID;
+      return parseConfiguration();
     }
     
-    return parseConfiguration();
+    return asynError;
 }
 
 


### PR DESCRIPTION
Member variable `dppType_` is being used before it is being assigned.
I noticed this when the TECS= issue from previous pull request was still present, but occurred only once, at startup.
I moved the assignment of `dppType_` to an early point. Now it happens only if the `CH_.HwCfgReady` is true, FWIW.
I guess returning an error from `readConfigurationFromHardware()` otherwise make sense.