### PR TITLE
broadcast to all interfaces that are up (Linux)

### DIFF
--- a/mcaApp/AmptekSrc/DppSocket.h
+++ b/mcaApp/AmptekSrc/DppSocket.h
@@ -52,14 +52,14 @@ public:
 	void NotCDppSocket2();
 
 	void SetTimeOut(long tv_sec, long tv_usec);		// set socket timout to new value
-	int SendNetFinderBroadCast(int m_rand);
+	int SendNetFinderBroadCast(int m_rand, int intf);
 
 	int UDPSendTo(const unsigned char * buf, int len, const char* lpIP, int nPort);
 	void SetBlockingMode();
 	int UDPRecvFrom(unsigned char * buf, int len, char* lpIP, int &nPort);
 	int UDPRecvFromNfAddr(unsigned char * buf, int len, char* lpIP, int &nPort);
 
-	int BroadCastSendTo(const void* lpBuf, int nBufLen, unsigned int nHostPort, const char *lpszHostAddress = NULL, int nFlags = 0);
+	int BroadCastSendTo(const void* lpBuf, int nBufLen, unsigned int nHostPort, const char *lpszInterface, int nFlags = 0);
 	int UDP_recvfrom_TimeOut();
 	int GetLocalSocketInfo();
 
@@ -92,6 +92,8 @@ public:
 	int NumDevices;					// Number of devices found by NetFinder
 	char DppAddr[20];				// hold DPP device IP Address
 	unsigned long ulNetFinderAddr;  // 
+	unsigned int numIntf;
+	char Intf[10][20];
 
 protected:
 	SOCKET m_hDppSocket;			// holds current socket descriptor


### PR DESCRIPTION
This is an initial attempt at broadcasting NetFinder UDP packets on port 3040 on all network interfaces that are up. Tested with IOC on Linux box with two DP5G devices on separate subnets.

The idea is to collect all the network interfaces that are up at `DppSocket()` creation and then broadcast the NetFinder packets to those interfaces by obtaining their broadcast address inside `CDppSocket::BroadCastSendTo()` using `SIOCGIFBRDADDR` ioctl (looking at this right now, I guess we could obtain the broadcast address in `DppSocket()` constructor and perform `SIOCGIFBRDADDR` ioctl only once).

Note that this is Linux specific change, AFAICT. I have not invested any time in getting this to work in Windows because I'm not familiar with it.
