### PR TITLE
Add epics-modules ci-scripts for Travis CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".ci"]
+	path = .ci
+	url = https://github.com/epics-base/ci-scripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,118 @@
+# .travis.xml for use with EPICS Base ci-scripts
+# (see: https://github.com/epics-base/ci-scripts)
+
+language: cpp
+compiler: gcc
+dist: xenial
+
+cache:
+  directories:
+  - $HOME/.cache
+
+env:
+  global:
+    - SETUP_PATH=.ci
+    - MODULES="sncseq sscan calc asyn std autosave busy"
+    - SNCSEQ=R2-2-8
+    - SSCAN=R2-11-3
+    - CALC=R3-7-3
+    - BUSY=R1-7-2
+    - STD=R3-6-1
+    - AUTOSAVE=R5-10
+    - ASYN=R4-38
+
+addons:
+  apt:
+    packages:
+    # for all EPICS builds
+    - libreadline6-dev
+    - libnet1-dev
+    - libpcap-dev
+    - libusb-1.0-0-dev
+    - libncurses5-dev
+    - perl
+    # for clang compiler
+    - clang
+    # for mingw builds (32bit and 64bit)
+    - g++-mingw-w64-i686
+    - g++-mingw-w64-x86-64
+    # for RTEMS cross builds
+    - qemu-system-x86
+  homebrew:
+    packages:
+    # for all EPICS builds
+    - bash
+    # for the sequencer
+    - re2c
+    # For libnet headers
+    - libnet
+    update: true
+
+install:
+  - ./.ci/travis/prepare.sh
+
+script:
+  - ./.ci/travis/build.sh
+
+# If you need to do more during install and build,
+# add a local directory to your module and do e.g.
+#  - ./.ci-local/travis/install-extras.sh
+
+# Define build jobs
+
+# Well-known variables to use
+# SET      source setup file
+# EXTRA    content will be added to make command line
+# STATIC   set to YES for static build (default: NO)
+# TEST     set to NO to skip running the tests (default: YES)
+# VV       set to make build scripts verbose (default: unset)
+
+# Usually from setup files, but may be specified or overridden
+#  on a job line
+# MODULES  list of dependency modules
+# BASE     branch or release tag name of the EPICS Base to use
+# <MODULE> branch or release tag for a specific module
+# ...      see README for setup file syntax description
+
+jobs:
+  include:
+
+# Default gcc and clang, static build
+
+  - env: BASE=7.0
+
+  - env: BASE=7.0
+    compiler: clang
+
+  - env: BASE=7.0 STATIC=YES
+
+# Trusty: compiler versions very close to RHEL 7
+
+  - env: BASE=7.0
+    dist: trusty
+
+# MacOS build
+
+  - env: BASE=7.0
+    os: osx
+    compiler: clang
+
+# # Older Base releases
+
+  - env: BASE=R3.15.7
+
+  - env: BASE=R3.15.7 STATIC=YES
+
+  - env: BASE=R3.14.12.8
+
+  - env: BASE=R3.14.12.8 STATIC=YES
+
+# Other gcc versions (added as an extra package)
+
+  - env: BASE=7.0
+    compiler: gcc-6
+    addons: { apt: { packages: ["g++-6", libnet1-dev, libpcap-dev, libusb-1.0-0-dev], sources: ["ubuntu-toolchain-r-test"] } }
+
+  - env: BASE=7.0
+    compiler: gcc-7
+    addons: { apt: { packages: ["g++-7", libnet1-dev, libpcap-dev, libusb-1.0-0-dev], sources: ["ubuntu-toolchain-r-test"] } }


### PR DESCRIPTION
Windows cross-compilation is currently removed due to issues with finding ntddndis.h:
```
/usr/bin/i686-w64-mingw32-gcc            -DUSE_WINPCAP -DWIN32   -D_MINGW -Wno-format     -O3   -Wall      -DUSE_WINPCAP -DWIN32   -m32       -I. -I../O.Common -I. -I. -I.. -I../../../include/compiler/gcc -I../../../include/os/WIN32 -I../../../include      -I/home/travis/.cache/calc-R3-7-3/include   -I/home/travis/.cache/sscan-R2-11-3/include   -I/home/travis/.cache/busy-R1-7-2/include   -I/home/travis/.cache/std-R3-6-1/include   -I/home/travis/.cache/seq-R2-2-8/include  -I/home/travis/.cache/autosave-R5-10/include/os/WIN32 -I/home/travis/.cache/autosave-R5-10/include   -I/home/travis/.cache/asyn-R4-38/include    -I/home/travis/.cache/base-7.0/include/compiler/gcc -I/home/travis/.cache/base-7.0/include/os/WIN32 -I/home/travis/.cache/base-7.0/include         -MM -MF nmc_comm_subs_1.d -MT nmc_comm_subs_1.o ../nmc_comm_subs_1.c
../nmc_comm_subs_1.c:109:32: fatal error: ddk/ntddndis.h: No such file or directory
```
RTEMS cross-compilation is also not present due to issues finding VME headers:
```
../rtemsDMA.h:6:29: error: bsp/vme_am_defs.h: No such file or directory
../rtemsDMA.h:7:24: error: bsp/VMEDMA.h: No such file or directory
```