### PR TITLE
Accept host names in drvAmptekConfigure()

### DIFF
--- a/mcaApp/AmptekSrc/drvAmptek.cpp
+++ b/mcaApp/AmptekSrc/drvAmptek.cpp
@@ -181,7 +181,7 @@ asynStatus drvAmptek::connectDevice()
     char dotaddr[] = "255.255.255.255";
     /* inet_ntoa() is not thread safe, and ipAddrToDottedIP() includes the port number */
     epicsInt32 my_addr = ntohl(addr.s_addr);
-    snprintf(dotaddr, sizeof(dotaddr), "%d.%d.%d.%d", (my_addr >> 24) & 0xFF, (my_addr >> 12) & 0xFF, (my_addr >> 8) & 0xFF, (my_addr) & 0xFF);
+    snprintf(dotaddr, sizeof(dotaddr), "%d.%d.%d.%d", (my_addr >> 24) & 0xFF, (my_addr >> 16) & 0xFF, (my_addr >> 8) & 0xFF, (my_addr) & 0xFF);
 
     if (interfaceType_ == DppInterfaceEthernet) {
         CH_.DppSocket.SetTimeOut((long)(TIMEOUT), (long)((TIMEOUT-(int)TIMEOUT)*1e6));

--- a/mcaApp/AmptekSrc/drvAmptek.cpp
+++ b/mcaApp/AmptekSrc/drvAmptek.cpp
@@ -180,6 +180,7 @@ asynStatus drvAmptek::connectDevice()
         asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
             "%s::%s ERROR: Network DPP device %s not found, total devices found=%d\n",
             driverName, functionName, addressInfo_, CH_.NumDevices);
+        return asynError;
     }
     CH_.DP5Stat.m_DP5_Status.SerialNumber = 0;
     if (CH_.SendCommand(XMTPT_SEND_STATUS) == false) {    // request status


### PR DESCRIPTION
The Amptek SDK expects the address as a string in IPv4 dotted-decimal notation so the host name needs to be resolved.