### PR TITLE
Support direct connect to device

### DIFF
--- a/documentation/mcaAmptek.html
+++ b/documentation/mcaAmptek.html
@@ -618,7 +618,7 @@
     The mca/iocBoot/iocAmptek contains example startup scripts for the Amptek detectors.</p>
   <p>
     The command to configure the Amptek driver is drvAmptekConfigure().</p>
-  <pre>int drvAmptekConfigure(const char *portName, int interfaceType, const char *addressInfo)
+  <pre>int drvAmptekConfigure(const char *portName, int interfaceType, const char *addressInfo, int directMode)
   The arguments are:
       portName:            # The name of the asyn port to be created
       interfaceType:       # The interface to use: 0=Ethernet, 1=USB, 2=RS-232
@@ -626,6 +626,7 @@
                            # For Ethernet this is the IP address of the module.
                            # For USB this argument is not used.
                            # RS-232 is not currently supported.
+      directMode:          # Enable broadcast-less connection: 0=use broadcast, 1=skip broadcast
 </pre>
   <h2 id="Restrictions">
     Restrictions</h2>

--- a/mcaApp/AmptekSrc/drvAmptek.cpp
+++ b/mcaApp/AmptekSrc/drvAmptek.cpp
@@ -57,7 +57,7 @@ static void exitHandlerC(void *arg)
 }
 }
 
-drvAmptek::drvAmptek(const char *portName, int interfaceType, const char *addressInfo)
+drvAmptek::drvAmptek(const char *portName, int interfaceType, const char *addressInfo, int directMode)
    : asynPortDriver(portName, 
                     MAX_SCAS, /* Maximum address */
                     0, /* Unused, number of parameters */
@@ -139,8 +139,10 @@ drvAmptek::drvAmptek(const char *portName, int interfaceType, const char *addres
     interfaceType_ = (DppInterface_t)interfaceType;
     switch(interfaceType_) {
         case DppInterfaceEthernet:
+        break;
         case DppInterfaceUSB:
         case DppInterfaceSerial:
+        directMode = 0;
         break;
         default:
             asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
@@ -149,6 +151,7 @@ drvAmptek::drvAmptek(const char *portName, int interfaceType, const char *addres
             return;
     }
     addressInfo_ = epicsStrDup(addressInfo);
+    directMode_  = directMode;
     
     status = connectDevice();
     if (status) {
@@ -162,6 +165,20 @@ drvAmptek::drvAmptek(const char *portName, int interfaceType, const char *addres
 void drvAmptek::exitHandler()
 {
     CH_.Close_Connection();
+}
+
+bool drvAmptek::directConnect(char* addr)
+{
+    if (! directMode_)
+        return false;
+
+    CH_.isConnected = false;
+    CH_.NumDevices = 0;
+    CH_.DppSocket_Connect_Direct_DPP(addr);
+    CH_.isConnected = CH_.DppSocket_isConnected;
+    CH_.NumDevices = CH_.DppSocket_NumDevices;
+
+    return CH_.isConnected;
 }
 
 asynStatus drvAmptek::connectDevice()
@@ -186,7 +203,18 @@ asynStatus drvAmptek::connectDevice()
     if (interfaceType_ == DppInterfaceEthernet) {
         CH_.DppSocket.SetTimeOut((long)(TIMEOUT), (long)((TIMEOUT-(int)TIMEOUT)*1e6));
     }
-    if (CH_.ConnectDpp(interfaceType_, dotaddr)) {
+    if (directMode_) {
+        if (directConnect(dotaddr)) {
+            asynPrint(pasynUserSelf, ASYN_TRACEIO_DRIVER,
+                "%s::%s DPP device %s connected\n",
+                driverName, functionName, addressInfo_);
+        } else {
+            asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
+                "%s::%s ERROR: Network DPP device %s not found, total devices found=%d\n",
+                driverName, functionName, addressInfo_, CH_.NumDevices);
+            return asynError;
+        }
+    } else if (CH_.ConnectDpp(interfaceType_, dotaddr)) {
         asynPrint(pasynUserSelf, ASYN_TRACEIO_DRIVER,
             "%s::%s DPP device %s connected, total devices found=%d\n",
             driverName, functionName, addressInfo_, CH_.NumDevices);
@@ -910,9 +938,9 @@ void drvAmptek::report(FILE *fp, int details)
 }
 
 extern "C" {
-int drvAmptekConfigure(const char *portName, int interfaceType, const char *addressInfo)
+int drvAmptekConfigure(const char *portName, int interfaceType, const char *addressInfo, int directMode)
 {
-    new drvAmptek(portName, interfaceType, addressInfo);
+    new drvAmptek(portName, interfaceType, addressInfo, directMode);
     return asynSuccess;
 }
 
@@ -920,13 +948,15 @@ int drvAmptekConfigure(const char *portName, int interfaceType, const char *addr
 static const iocshArg configArg0 = { "portName", iocshArgString};
 static const iocshArg configArg1 = { "interface", iocshArgInt};
 static const iocshArg configArg2 = { "address info", iocshArgString};
+static const iocshArg configArg3 = { "direct mode", iocshArgInt};
 static const iocshArg * const configArgs[] = {&configArg0,
                                               &configArg1,
-                                              &configArg2};
-static const iocshFuncDef configFuncDef = {"drvAmptekConfigure", 3, configArgs};
+                                              &configArg2,
+                                              &configArg3};
+static const iocshFuncDef configFuncDef = {"drvAmptekConfigure", 4, configArgs};
 static void configCallFunc(const iocshArgBuf *args)
 {
-    drvAmptekConfigure(args[0].sval, args[1].ival, args[2].sval);
+    drvAmptekConfigure(args[0].sval, args[1].ival, args[2].sval, args[3].ival);
 }
 
 void drvAmptekRegister(void)

--- a/mcaApp/AmptekSrc/drvAmptek.cpp
+++ b/mcaApp/AmptekSrc/drvAmptek.cpp
@@ -181,7 +181,7 @@ asynStatus drvAmptek::connectDevice()
     char dotaddr[] = "255.255.255.255";
     /* inet_ntoa() is not thread safe, and ipAddrToDottedIP() includes the port number */
     epicsInt32 my_addr = ntohl(addr.s_addr);
-    snprintf(dotaddr, sizeof(dotaddr), "%d.%d.%d.%d", (my_addr >> 24) & 0xFF, (my_addr >> 12) & 0xFF, (my_addr >> 8) & 0xFF, (my_addr) & 0xFF);
+    snprintf(dotaddr, sizeof(dotaddr), "%d.%d.%d.%d", (my_addr >> 24) & 0xFF, (my_addr >> 16) & 0xFF, (my_addr >> 8) & 0xFF, (my_addr) & 0xFF);
 
     if (interfaceType_ == DppInterfaceEthernet) {
         CH_.DppSocket.SetTimeOut((long)(TIMEOUT), (long)((TIMEOUT-(int)TIMEOUT)*1e6));

--- a/mcaApp/AmptekSrc/drvAmptek.cpp
+++ b/mcaApp/AmptekSrc/drvAmptek.cpp
@@ -180,6 +180,7 @@ asynStatus drvAmptek::connectDevice()
         asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
             "%s::%s ERROR: Network DPP device %s not found, total devices found=%d\n",
             driverName, functionName, addressInfo_, CH_.NumDevices);
+        return asynError;
     }
     CH_.DP5Stat.m_DP5_Status.SerialNumber = 0;
     if (CH_.SendCommand(XMTPT_SEND_STATUS) == false) {    // request status

--- a/mcaApp/AmptekSrc/drvAmptek.h
+++ b/mcaApp/AmptekSrc/drvAmptek.h
@@ -65,7 +65,7 @@ class drvAmptek : public asynPortDriver
 {
   
   public:
-  drvAmptek(const char *portName, int interfaceType, const char *addressInfo);
+  drvAmptek(const char *portName, int interfaceType, const char *addressInfo, int directMode);
 
   // These are the methods we override from asynPortDriver
   asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);
@@ -148,6 +148,7 @@ class drvAmptek : public asynPortDriver
   CConsoleHelper CH_;
   CONFIG_OPTIONS configOptions_;
   asynStatus connectDevice();
+  bool       directConnect(char* address);
   asynStatus findModule();
   asynStatus sendCommand(TRANSMIT_PACKET_TYPE command);
   asynStatus sendCommandString(string commandString);
@@ -165,6 +166,7 @@ class drvAmptek : public asynPortDriver
   bool haveConfigFromHW_;
   DppInterface_t interfaceType_;
   char *addressInfo_;
+  bool directMode_;
   epicsInt32 *pData_;
   size_t numChannels_;
 };


### PR DESCRIPTION
This PR is based on #16 and adds support for broadcast-less connect: since the IP address of the device is known we can skip the "find all the devices" step. This could potentially help with problems mentioned in #14 . I can confirm that it does help when the device refuses to answer to broadcasts.