### PR TITLE
Fixed Amptek USB connection

### DIFF
--- a/mcaApp/AmptekSrc/Makefile
+++ b/mcaApp/AmptekSrc/Makefile
@@ -39,6 +39,7 @@ ifeq ($(LINUX_LIBUSB-1.0_INSTALLED),YES)
   LIBRARY_IOC_Linux += mcaAmptek
   PROD_IOC_Linux    += mcaAmptekApp
   PROD_IOC_Linux    += gccDppConsoleInet
+  PROD_IOC_Linux    += amptekTest1
 endif
 
 USR_INCLUDES_Linux += -I/usr/include/libusb-1.0
@@ -94,6 +95,13 @@ gccDppConsoleInet_LIBS += mcaAmptek
 gccDppConsoleInet_LIBS += $(EPICS_BASE_IOC_LIBS)
 gccDppConsoleInet_SYS_LIBS_Linux += usb-1.0
 gccDppConsoleInet_LIBS_WIN32 += libusb-1.0
+
+#=============================
+amptekTest1_SRCS += amptekTest1.cpp
+amptekTest1_LIBS += mcaAmptek
+amptekTest1_LIBS += $(EPICS_BASE_IOC_LIBS)
+amptekTest1_SYS_LIBS_Linux += usb-1.0
+amptekTest1_LIBS_WIN32 += libusb-1.0
 
 include $(TOP)/configure/RULES
 #----------------------------------------

--- a/mcaApp/AmptekSrc/amptekTest1.cpp
+++ b/mcaApp/AmptekSrc/amptekTest1.cpp
@@ -129,7 +129,10 @@ int main(int argc, char * argv[])
 	
 	strcpy(szDPP_Send, argv[1]);
 
-	if (! chdpp.DppSocket_Connect_Default_DPP(szDPP_Send)) { return 1;}
+	// Uncomment for Ethernet test
+	//if (! chdpp.DppSocket_Connect_Default_DPP(szDPP_Send)) { return 1;}
+	// Uncomment for USB test
+	if (! chdpp.LibUsb_Connect_Default_DPP()) { return 1;}
 	
   // Get the DPP Status
 	chdpp.DP5Stat.m_DP5_Status.SerialNumber = 0;

--- a/mcaApp/AmptekSrc/drvAmptek.cpp
+++ b/mcaApp/AmptekSrc/drvAmptek.cpp
@@ -188,19 +188,19 @@ asynStatus drvAmptek::connectDevice()
     static const char *functionName = "connectDevice";
 
     struct in_addr addr;
-    if (hostToIPAddr(addressInfo_, &addr)) {
-        asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
-            "%s::%s ERROR: Cannot resolve address: %s\n",
-            driverName, functionName, addressInfo_);
-        return asynError;
-    }
 
     char dotaddr[] = "255.255.255.255";
     /* inet_ntoa() is not thread safe, and ipAddrToDottedIP() includes the port number */
-    epicsInt32 my_addr = ntohl(addr.s_addr);
-    snprintf(dotaddr, sizeof(dotaddr), "%d.%d.%d.%d", (my_addr >> 24) & 0xFF, (my_addr >> 16) & 0xFF, (my_addr >> 8) & 0xFF, (my_addr) & 0xFF);
-
     if (interfaceType_ == DppInterfaceEthernet) {
+        if (hostToIPAddr(addressInfo_, &addr)) {
+            asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
+                "%s::%s ERROR: Cannot resolve address: %s\n",
+                driverName, functionName, addressInfo_);
+            return asynError;
+        }
+        epicsInt32 my_addr = ntohl(addr.s_addr);
+        snprintf(dotaddr, sizeof(dotaddr), "%d.%d.%d.%d", (my_addr >> 24) & 0xFF, (my_addr >> 16) & 0xFF, (my_addr >> 8) & 0xFF, (my_addr) & 0xFF);
+
         CH_.DppSocket.SetTimeOut((long)(TIMEOUT), (long)((TIMEOUT-(int)TIMEOUT)*1e6));
     }
     if (directMode_) {


### PR DESCRIPTION
Problem with Amptek USB connection was that IP connection superceded all connection methods. Problem fixed by changing order of operations, embedding IP operations after (and within "if" block of) checking if method is IP.  Addresses Issue #27 