### PR TITLE
Initialize pData on Amptek to avoid double free errors

### DIFF
--- a/mcaApp/AmptekSrc/drvAmptek.h
+++ b/mcaApp/AmptekSrc/drvAmptek.h
@@ -167,7 +167,7 @@ class drvAmptek : public asynPortDriver
   DppInterface_t interfaceType_;
   char *addressInfo_;
   bool directMode_;
-  epicsInt32 *pData_;
+  epicsInt32 *pData_ = NULL;
   size_t numChannels_;
 };
 


### PR DESCRIPTION
When upgrading from Debian Buster to Bullseye we noticed that the IOC was crashing after `IocInit()`. Turns out if was crashing at https://github.com/epics-modules/mca/blob/a2e224b4c8146818276e3097ab60fbd3de41b291/mcaApp/AmptekSrc/drvAmptek.cpp#L773
I assume that something in glibc or in the configuration (EPICS, gcc optimizations, etc) we are using cleared the memory in Buster, but not in Bullseye.

I could also initialize in https://github.com/epics-modules/mca/blob/a2e224b4c8146818276e3097ab60fbd3de41b291/mcaApp/AmptekSrc/drvAmptek.cpp#L60 if preferred, but I think it is neater to do it in the header (please feel free to convince me otherwise). Once pData is used once, it becomes initialized, so the bug does not manifest itself.
<details>
<summary>
Backtrace of error done with gdb
</summary>

```
  ########################ee0027 In: __GI_raise############################### L50 PC: 0x7ffff781fce1
  #0 __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
  #1 0x00007ffff7809537 in __GI_abort () at abort.c:79
  #2 0x00007ffff7862768 in __libc_message (action=action@entry=do_abort,
  fmt=fmt@entry=0x7ffff7970e2d "%s\n") at ../sysdeps/posix/libc_fatal.c:155
  #3 0x00007ffff7869a5a in malloc_printerr (str=str@entry=0x7ffff796f05a "free(): invalid pointer")
  at malloc.c:5347
  #4 0x00007ffff786ac14 in _int_free (av=<optimized out>, p=<optimized out>, have_lock=0)
  at malloc.c:4173
  #5 0x0000555555570ffe in drvAmptek::writeInt32 (this=0x5555562f24a0, pasynUser=<optimized out>,
  value=8192) at ../drvAmptek.cpp:778
  #6 0x00007ffff7e8026d in ?? () from /lib/x86_64-linux-gnu/libasyn.so.4.38
  #7 0x00007ffff7fc44e2 in asynCallback (pasynUser=0x5555563dd918) at ../devMcaAsyn.c:386
  #8 0x00007ffff7e60ead in ?? () from /lib/x86_64-linux-gnu/libasyn.so.4.38
  #9 0x00007ffff7d380bb in ?? () from /lib/x86_64-linux-gnu/libCom.so.3.15.9
  --Type <RET> for more, q to quit, c to continue without paging--u
```
</details>