### PR TITLE
Usb fixes

### DIFF
--- a/mcaApp/AmptekSrc/ConsoleHelper.cpp
+++ b/mcaApp/AmptekSrc/ConsoleHelper.cpp
@@ -600,7 +600,7 @@ bool CConsoleHelper::LibUsb_SendCommand(TRANSMIT_PACKET_TYPE XmtCmd)
         bHaveBuffer = (bool) SndCmd.DP5_CMD(DP5Proto.BufferOUT, XmtCmd);
         if (bHaveBuffer) {
             bSentPkt = DppLibUsb.SendPacketUSB(DppLibUsb.DppLibusbHandle, DP5Proto.BufferOUT, DP5Proto.PacketIn);
-            if (bSentPkt) {
+            if (bSentPkt > 0) {
                 bMessageSent = true;
             }
         }
@@ -671,7 +671,7 @@ bool CConsoleHelper::LibUsb_SendCommand_Config(TRANSMIT_PACKET_TYPE XmtCmd, CONF
         bHaveBuffer = (bool) SndCmd.DP5_CMD_Config(DP5Proto.BufferOUT, XmtCmd, CfgOptions);
         if (bHaveBuffer) {
             bSentPkt = DppLibUsb.SendPacketUSB(DppLibUsb.DppLibusbHandle, DP5Proto.BufferOUT, DP5Proto.PacketIn);
-            if (bSentPkt) {
+            if (bSentPkt > 0) {
                 bMessageSent = true;
             }
         }

--- a/mcaApp/AmptekSrc/DppLibUsb.cpp
+++ b/mcaApp/AmptekSrc/DppLibUsb.cpp
@@ -44,7 +44,7 @@ libusb_device_handle * CDppLibUsb::FindUSBDevice(int idxAmptekDevice)
 	bDeviceConnected = false;
 	devcnt = libusb_get_device_list(NULL, &devs);
 	if (devcnt < 0) {
-		fprintf(stderr, "failed to get device list");
+		fprintf(stderr, "failed to get device list: %s\n", libusb_strerror((libusb_error)devcnt));
 		return NULL;
 	}
 	for (iDev = 0; iDev < devcnt; iDev++) {
@@ -67,7 +67,7 @@ libusb_device_handle * CDppLibUsb::FindUSBDevice(int idxAmptekDevice)
 	if (found) {
 		r = libusb_open(found, &handle);
 		if (r < 0) {
-			fprintf(stderr, libusb_strerror((libusb_error)r));
+			fprintf(stderr, "Cannot open USB device: %s\n", libusb_strerror((libusb_error)r));
 			handle = NULL;
 		} else {
 			if (handle != NULL) {
@@ -125,15 +125,15 @@ int CDppLibUsb::SendPacketUSB(libusb_device_handle *devh, unsigned char data_out
 			if (bytes_transferred > 0) {
 				return bytes_transferred;
 			} else {
-				fprintf(stderr, "No data received in bulk transfer (%d)\n", result);
+				fprintf(stderr, "No data received in bulk transfer: %s\n", libusb_strerror(libusb_error)result));
 				return -1;
 			}
 		} else {
-			fprintf(stderr, "Error receiving data via bulk transfer %d\n", result);
+			fprintf(stderr, "Error receiving data via bulk transfer: %s\n", libusb_strerror(libusb_error)result));
 			return result;
 		}
 	} else {
-		fprintf(stderr, "Error sending data via bulk transfer %d\n", result);
+		fprintf(stderr, "Error sending data via bulk transfer: %s\n", libusb_strerror(libusb_error)result));
 		return result;
 	}
   	return 0;
@@ -157,8 +157,10 @@ int CDppLibUsb::CountDP5LibusbDevices()
 	int iDppCount=0;
 
 	ssize_t cnt = libusb_get_device_list (NULL, &devs); 
-	if (cnt < 0)
+	if (cnt < 0) {
+		fprintf(stderr, "failed to get device list: %s\n", libusb_strerror((libusb_error)cnt));
 		return (-1);
+	}
 	int nr = 0, i = 0;
 	struct libusb_device_descriptor desc;
 	for (i = 0; i < cnt; ++i)
@@ -185,7 +187,7 @@ void CDppLibUsb::PrintDevices()
 
 	cnt = libusb_get_device_list(NULL, &devs);
 	if (cnt < 0) {
-		fprintf(stderr, "failed to get device list");
+		fprintf(stderr, "failed to get device list: %s\n", libusb_strerror((libusb_error)cnt));
 		return;
 	}
 

--- a/mcaApp/AmptekSrc/DppLibUsb.cpp
+++ b/mcaApp/AmptekSrc/DppLibUsb.cpp
@@ -76,6 +76,8 @@ libusb_device_handle * CDppLibUsb::FindUSBDevice(int idxAmptekDevice)
 					bDeviceConnected = true; // have interface
 				} else {
 					fprintf(stderr, "libusb_claim_interface error %s\n", libusb_strerror((libusb_error)r));
+					libusb_close(handle);
+					handle = NULL;
 				}
 			} else {
 				fprintf(stderr, "Unable to find a dpp device.\n");


### PR DESCRIPTION
This PR

- adds verbose USB error logging; instead of just the error code print the error message itself
- closes the open USB handle if claiming the interface was unsuccessful
- sets `bMessageSent` only if `bSentPkt` is greater than 0. Negative return codes means failure