### PR TITLE
Initialize interfaceType when using directMode=1

### DIFF
--- a/mcaApp/AmptekSrc/ConsoleHelper.cpp
+++ b/mcaApp/AmptekSrc/ConsoleHelper.cpp
@@ -348,6 +348,7 @@ bool CConsoleHelper::DppSocket_Connect_Direct_DPP(char szDPP_Send[])
 {
     unsigned long lTestAddr;
     unsigned long lDppAddr;
+    interfaceType = DppInterfaceEthernet;
     DppSocket_isConnected = false;
     DppSocket.deviceConnected = false;
     DppSocket_NumDevices = 0;


### PR DESCRIPTION
Hi Mark,

Another round of OS updates that seemingly had nothing to do with IOCs and suddenly we start having issues with one of our devices. Like the `pData` initialization (https://github.com/epics-modules/mca/commit/0ddd7865f8e06651b9a45a89fd8bf353e1d81989), I suspect the new toolchain optimizes things differently and exposes non-initialized variables. In this case, it seems like `interfaceType` was not initialized when `directMode=1`. Since `DppInterfaceEthernet=0`, if the initial value for all members is zeroed out, the bug is not exposed (which was the case in the past).

Like last time, there might be a few different spots to implement this fix. I'm sending one that I think makes sense (initialize interfaceType in the `Connect_Direct_DPP` function (as a mirror of the `ConnectDPP` function). That said, we could also initialize it in the `CConsoleHelper` constructor (creating a "default" `interfaceType`) or even in the `drvAmptek::directConnect` function, right before the call to `CH_.DppSocket_Connect_Direct_DPP(addr);`. I think this last option is a bit worse, in the sense that the `ConsoleHelper.cpp` library would require this non-intuitive initialization of the interface type (whereas `connectDpp` uses the argument of the function to initialize the type.

I look forward to your opinions on this.